### PR TITLE
bump wiremock to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-wiremock = "0.5"
+wiremock = "0.6"
 lazy-regex = "2.2"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,15 +55,11 @@ mod test_utils {
     use std::collections::HashMap;
     use std::str::FromStr;
 
-    use wiremock::http::{HeaderMap, HeaderName, HeaderValue, Method, Url};
+    use wiremock::http::{HeaderName, HeaderValue, Method, Url};
     use wiremock::Request;
 
     pub fn name(name: &'static str) -> HeaderName {
         HeaderName::from_str(name).unwrap()
-    }
-
-    pub fn value(val: &'static str) -> HeaderValue {
-        HeaderValue::from_str(val).unwrap()
     }
 
     pub fn values(val: &'static str) -> HeaderValue {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,14 +34,16 @@
 //! }
 //! ```
 
-#[cfg(test)] extern crate indoc;
-#[cfg(test)] extern crate maplit;
-extern crate wiremock;
+#[cfg(test)]
+extern crate indoc;
 extern crate lazy_regex;
+#[cfg(test)]
+extern crate maplit;
+extern crate wiremock;
 
-mod request_utils;
-mod part;
 pub mod matchers;
+mod part;
+mod request_utils;
 
 pub mod prelude {
     pub use crate::matchers::*;
@@ -49,11 +51,11 @@ pub mod prelude {
 
 #[cfg(test)]
 mod test_utils {
+    use maplit::hashmap;
     use std::collections::HashMap;
     use std::str::FromStr;
-    use maplit::hashmap;
 
-    use wiremock::http::{HeaderName, HeaderValue, HeaderValues, Method, Url};
+    use wiremock::http::{HeaderMap, HeaderName, HeaderValue, Method, Url};
     use wiremock::Request;
 
     pub fn name(name: &'static str) -> HeaderName {
@@ -64,32 +66,29 @@ mod test_utils {
         HeaderValue::from_str(val).unwrap()
     }
 
-    pub fn values(val: &'static str) -> HeaderValues {
-        value(val).into()
+    pub fn values(val: &'static str) -> HeaderValue {
+        HeaderValue::from_str(val).unwrap()
     }
 
-    pub fn request(
-        headers: HashMap<HeaderName, HeaderValues>,
-    ) -> Request {
+    pub fn request(headers: impl IntoIterator<Item = (HeaderName, HeaderValue)>) -> Request {
         requestb(headers, vec![])
     }
 
     pub fn requestb(
-        headers: HashMap<HeaderName, HeaderValues>,
+        headers: impl IntoIterator<Item = (HeaderName, HeaderValue)>,
         body: Vec<u8>,
     ) -> Request {
         Request {
             url: Url::from_str("http://localhost").unwrap(),
-            method: Method::Post,
-            headers,
+            method: Method::POST,
+            headers: headers.into_iter().collect(),
             body,
         }
     }
 
-    pub fn multipart_header() -> HashMap<HeaderName, HeaderValues> {
-        hashmap!{
+    pub fn multipart_header() -> HashMap<HeaderName, HeaderValue> {
+        hashmap! {
             name("content-type") => values("multipart/form-data; boundary=xyz"),
         }
     }
 }
-

--- a/src/request_utils.rs
+++ b/src/request_utils.rs
@@ -12,45 +12,39 @@ pub trait RequestUtils {
 
 impl RequestUtils for Request {
     fn multipart_contenttype(&self) -> Option<MultipartContentType> {
-        let content_type = self.headers.get(&HeaderName::from_str("content-type").unwrap());
-
+        let content_type = self
+            .headers
+            .get_all(&HeaderName::from_str("content-type").unwrap())
+            .iter()
+            .find(|value| {
+                value
+                    .to_str()
+                    .unwrap_or_default()
+                    .to_lowercase()
+                    .starts_with("multipart/")
+            });
         match content_type {
             None => None,
-            Some(content_type) => {
-                let multipart_value = content_type.iter().find(|value| {
-                    value.as_str().to_lowercase().starts_with("multipart/")
-                });
-                match multipart_value {
-                    None => None,
-                    Some(value) => {
-                        let parts = value.as_str().split(";").collect::<Vec<_>>();
+            Some(value) => {
+                let parts = value
+                    .to_str()
+                    .unwrap_or_default()
+                    .split(";")
+                    .collect::<Vec<_>>();
 
-                        let multipart_type = parts[0].split("/")
-                            .nth(1)
-                            .unwrap()
-                            .trim();
+                let multipart_type = parts[0].split("/").nth(1).unwrap().trim();
 
-                        let boundary = parts.iter()
-                            .map(|part| part.trim())
-                            .find(|part| {
-                                part.starts_with("boundary=")
-                            })
-                            .map(|whole| {
-                                whole.split("=")
-                                    .nth(1)
-                                    .unwrap()
-                                    .trim()
-                            });
+                let boundary = parts
+                    .iter()
+                    .map(|part| part.trim())
+                    .find(|part| part.starts_with("boundary="))
+                    .map(|whole| whole.split("=").nth(1).unwrap().trim());
 
-                        Some(
-                            MultipartContentType {
-                                multipart_type,
-                                boundary,
-                            },
-                        )
-                    },
-                }
-            },
+                Some(MultipartContentType {
+                    multipart_type,
+                    boundary,
+                })
+            }
         }
     }
 
@@ -66,7 +60,8 @@ impl RequestUtils for Request {
                         tmp
                     };
 
-                    let boundary_start_indexes = self.body
+                    let boundary_start_indexes = self
+                        .body
                         .windows(boundary.len())
                         .enumerate()
                         .filter(|(_, window)| window == &boundary)
@@ -76,9 +71,7 @@ impl RequestUtils for Request {
                     boundary_start_indexes
                         .windows(2)
                         .map(|w| (boundary.len() + 1 + w[0], w[1]))
-                        .map(|(start, end)| {
-                            &self.body[start..end]
-                        })
+                        .map(|(start, end)| &self.body[start..end])
                         .map(|body| trim_single_linebreak_from_start(body))
                         .map(|body| trim_single_linebreak_from_end(body))
                         .map(|it| Part::from(it))
@@ -146,28 +139,21 @@ mod tests {
 
     #[test]
     fn multipart_contenttype_should_return_none_if_no_multipart_request() {
+        assert_eq!(request(hashmap! {},).multipart_contenttype(), None);
+
         assert_eq!(
-            request(
-                hashmap!{},
-            ).multipart_contenttype(),
+            request(hashmap! {
+                name("accept") => values("application/json"),
+            },)
+            .multipart_contenttype(),
             None
         );
 
         assert_eq!(
-            request(
-                hashmap!{
-                    name("accept") => values("application/json"),
-                },
-            ).multipart_contenttype(),
-            None
-        );
-
-        assert_eq!(
-            request(
-                hashmap!{
-                    name("content-type") => values("image/jpeg"),
-                },
-            ).multipart_contenttype(),
+            request(hashmap! {
+                name("content-type") => values("image/jpeg"),
+            },)
+            .multipart_contenttype(),
             None
         );
     }
@@ -175,31 +161,25 @@ mod tests {
     #[test]
     fn multipart_contenttype_should_return_some_if_multipart_request() {
         assert_eq!(
-            request(
-                hashmap!{
-                    name("content-type") => values("multipart/foo"),
-                },
-            ).multipart_contenttype(),
-            Some(
-                MultipartContentType {
-                    multipart_type: "foo",
-                    boundary: None,
-                }
-            )
+            request(hashmap! {
+                name("content-type") => values("multipart/foo"),
+            },)
+            .multipart_contenttype(),
+            Some(MultipartContentType {
+                multipart_type: "foo",
+                boundary: None,
+            })
         );
 
         assert_eq!(
-            request(
-                hashmap!{
-                    name("content-type") => values("multipart/bar; boundary=xyz"),
-                },
-            ).multipart_contenttype(),
-            Some(
-                MultipartContentType {
-                    multipart_type: "bar",
-                    boundary: Some("xyz"),
-                }
-            )
+            request(hashmap! {
+                name("content-type") => values("multipart/bar; boundary=xyz"),
+            },)
+            .multipart_contenttype(),
+            Some(MultipartContentType {
+                multipart_type: "bar",
+                boundary: Some("xyz"),
+            })
         );
     }
 
@@ -207,20 +187,23 @@ mod tests {
     fn parts_should_find_single_text_part() {
         assert_eq!(
             requestb(
-                hashmap!{
+                hashmap! {
                     name("content-type") => values("multipart/form-data; boundary=xyz"),
                 },
-                indoc!{"
+                indoc! {"
                     --xyz
                     Content-Disposition: form-data; name=\"part1\"
 
                     content
                     --xyz--
-                "}.as_bytes().into(),
-            ).parts(),
-            vec![
-                Part::from("Content-Disposition: form-data; name=\"part1\"\n\ncontent"),
-            ],
+                "}
+                .as_bytes()
+                .into(),
+            )
+            .parts(),
+            vec![Part::from(
+                "Content-Disposition: form-data; name=\"part1\"\n\ncontent"
+            ),],
         );
     }
 
@@ -229,11 +212,14 @@ mod tests {
         assert_eq!(
             requestb(
                 multipart_header(),
-                "--xyz\r\nContent-Disposition: form-data; name=\"part1\"\r\n\r\ncontent\r\n--xyz--".as_bytes().into()
-            ).parts(),
-            vec![
-                Part::from("Content-Disposition: form-data; name=\"part1\"\r\n\r\ncontent"),
-            ],
+                "--xyz\r\nContent-Disposition: form-data; name=\"part1\"\r\n\r\ncontent\r\n--xyz--"
+                    .as_bytes()
+                    .into()
+            )
+            .parts(),
+            vec![Part::from(
+                "Content-Disposition: form-data; name=\"part1\"\r\n\r\ncontent"
+            ),],
         );
     }
 
@@ -241,10 +227,10 @@ mod tests {
     fn parts_should_find_two_text_parts() {
         assert_eq!(
             requestb(
-                hashmap!{
+                hashmap! {
                     name("content-type") => values("multipart/form-data; boundary=xyz"),
                 },
-                indoc!{r#"
+                indoc! {r#"
                     --xyz
                     Content-Disposition: form-data; name="part1"
 
@@ -260,11 +246,14 @@ mod tests {
                     ]
 
                     --xyz--
-                "#}.as_bytes().into(),
-            ).parts(),
+                "#}
+                .as_bytes()
+                .into(),
+            )
+            .parts(),
             vec![
                 Part::from("Content-Disposition: form-data; name=\"part1\"\n\ncontent"),
-                Part::from(indoc!{r#"
+                Part::from(indoc! {r#"
                     Content-Disposition: form-data; name="file"; filename="Cargo.toml"
                     Content-Type: plain/text
 
@@ -298,10 +287,7 @@ mod tests {
         body += "\r\n--xyz--\r\n";
 
         assert_eq!(
-            requestb(
-                multipart_header(),
-                body.as_bytes().into(),
-            ).parts(),
+            requestb(multipart_header(), body.as_bytes().into(),).parts(),
             vec![
                 Part::from("Content-Disposition: form-data; name=\"part1\"\r\n\r\ncontent"),
                 Part::from(&part2),


### PR DESCRIPTION
:wave: I'm not sure if the maintainer is still around. But we use this crate at my company for testing. 

Unfortunately, this crate doesn't fully work with wiremock 0.6.

Cargo is happy to have the current version in the same crate with the latest wiremock. However, it breaks down in use. Here's an example failure where the parts matcher no longer satisfies the `Match` trait in new wiremock:

```
error[E0277]: the trait bound `wiremock_multipart::matchers::NumberOfParts: wiremock::Match` is not satisfied
   --> crates/clients/src/http.rs:450:18
    |
450 |             .and(NumberOfParts(2))
    |              --- ^^^^^^^^^^^^^^^^ the trait `for<'a> Fn(&'a wiremock::Request)` is not implemented for `wiremock_multipart::matchers::NumberOfParts`, which is required by `wiremock_multipart::matchers::NumberOfParts: wiremock::Match`
    |              |
    |              required by a bound introduced by this call
    |
    = help: the following other types implement trait `wiremock::Match`:
              AnyMatcher
              BasicAuthMatcher
              BearerTokenMatcher
              BodyContainsMatcher
              BodyExactMatcher
              BodyPartialJsonMatcher
              HeaderExactMatcher
              HeaderExistsMatcher
            and 8 others
```

In this PR, I bumped the version and fixed APIs broken by wiremock-multipart 0.6.


I'd love to get this crate updated over using my fork. Please let me know what I can do to help!